### PR TITLE
fix the PlayerListener onPlayerQuit

### DIFF
--- a/src/main/java/dev/kaepsis/cachedeconomy/listeners/PlayerListener.java
+++ b/src/main/java/dev/kaepsis/cachedeconomy/listeners/PlayerListener.java
@@ -35,7 +35,7 @@ public class PlayerListener implements Listener {
         Player player = event.getPlayer();
         String playerName = player.getName();
 
-        double balance = cacheStorage.getBalance(playerName);
+        double balance = cacheStorage.getCachedBalance(playerName);
         playerStorage.setBalance(playerName, balance);
         Main.savedPlayers.remove(playerName);
     }


### PR DESCRIPTION
When a player leaves the server, their balance is always saved as 0.0, regardless of the actual amount. This happens because PlayerListener#onPlayerQuit uses cacheStorage.getBalance(playerName), which currently returns 0D unconditionally.